### PR TITLE
게임판 출력 기능 구현

### DIFF
--- a/minesweeper-client/minesweeper/board/board.go
+++ b/minesweeper-client/minesweeper/board/board.go
@@ -10,6 +10,7 @@ import (
 type Board struct {
 	cells         [][]cell.Cell
 	landMineCount int
+	flagCount     int
 	gameStatus    GameStatus
 }
 
@@ -39,6 +40,10 @@ func (board *Board) InitializeGame() {
 
 	numberPositions := cellPositions.Subtract(landMinePositions)
 	board.initializeNumberCells(numberPositions)
+}
+
+func (board *Board) GetRemainingFlags() int {
+	return board.landMineCount - board.flagCount
 }
 
 func (board *Board) GetSnapshot(cellPosition *position.CellPosition) cell.Snapshot {

--- a/minesweeper-client/minesweeper/board/board.go
+++ b/minesweeper-client/minesweeper/board/board.go
@@ -41,9 +41,22 @@ func (board *Board) InitializeGame() {
 	board.initializeNumberCells(numberPositions)
 }
 
+func (board *Board) GetSnapshot(cellPosition *position.CellPosition) cell.Snapshot {
+	boardCell := board.cells[cellPosition.RowIndex()][cellPosition.ColIndex()]
+	return boardCell.GetSnapshot()
+}
+
+func (board *Board) GetColSize() int {
+	return len(board.cells[0])
+}
+
+func (board *Board) GetRowSize() int {
+	return len(board.cells)
+}
+
 func (board *Board) initializeEmptyCells() {
 	for rowIndex, row := range board.cells {
-		for colIndex, _ := range row {
+		for colIndex := range row {
 			board.cells[rowIndex][colIndex] = cell.NewEmptyCell()
 		}
 	}
@@ -102,8 +115,8 @@ func (board *Board) isLandMineCell(cellPosition *position.CellPosition) bool {
 }
 
 func (board *Board) isOutOfBounds(cellPosition *position.CellPosition) bool {
-	rowSize := len(board.cells)
-	colSize := len(board.cells[0])
+	rowSize := board.GetRowSize()
+	colSize := board.GetColSize()
 
 	return cellPosition.RowIndex() < 0 || cellPosition.ColIndex() < 0 ||
 		cellPosition.RowIndex() >= rowSize || cellPosition.ColIndex() >= colSize

--- a/minesweeper-client/minesweeper/cell/cell.go
+++ b/minesweeper-client/minesweeper/cell/cell.go
@@ -5,4 +5,5 @@ type Cell interface {
 	IsOpened() bool
 	IsFlagged() bool
 	HasAdjacentLandMines() bool
+	GetSnapshot() Snapshot
 }

--- a/minesweeper-client/minesweeper/cell/cell_snapshot.go
+++ b/minesweeper-client/minesweeper/cell/cell_snapshot.go
@@ -1,0 +1,38 @@
+package cell
+
+type Snapshot struct {
+	status                SnapshotStatus
+	adjacentLandMineCount int
+}
+
+func NewCellSnapshot(status SnapshotStatus, adjacentLandMineCount int) Snapshot {
+	return Snapshot{status: status, adjacentLandMineCount: adjacentLandMineCount}
+}
+
+func OfUnchecked() Snapshot {
+	return NewCellSnapshot(Unchecked, 0)
+}
+
+func OfEmpty() Snapshot {
+	return NewCellSnapshot(Empty, 0)
+}
+
+func OfFlag() Snapshot {
+	return NewCellSnapshot(Flag, 0)
+}
+
+func OfLandMine() Snapshot {
+	return NewCellSnapshot(LandMine, 0)
+}
+
+func OfNumber(adjacentLandMineCount int) Snapshot {
+	return NewCellSnapshot(Number, adjacentLandMineCount)
+}
+
+func (snapshot Snapshot) GetStatus() SnapshotStatus {
+	return snapshot.status
+}
+
+func (snapshot Snapshot) GetAdjacentLandMineCount() int {
+	return snapshot.adjacentLandMineCount
+}

--- a/minesweeper-client/minesweeper/cell/cell_snapshot_status.go
+++ b/minesweeper-client/minesweeper/cell/cell_snapshot_status.go
@@ -1,0 +1,11 @@
+package cell
+
+type SnapshotStatus int
+
+const (
+	Unchecked SnapshotStatus = iota
+	Empty
+	Flag
+	LandMine
+	Number
+)

--- a/minesweeper-client/minesweeper/cell/empty.go
+++ b/minesweeper-client/minesweeper/cell/empty.go
@@ -23,3 +23,13 @@ func (c *EmptyCell) IsFlagged() bool {
 func (c *EmptyCell) HasAdjacentLandMines() bool {
 	return false
 }
+
+func (c *EmptyCell) GetSnapshot() Snapshot {
+	if c.IsOpened() {
+		return OfEmpty()
+	}
+	if c.IsFlagged() {
+		return OfFlag()
+	}
+	return OfUnchecked()
+}

--- a/minesweeper-client/minesweeper/cell/landmine.go
+++ b/minesweeper-client/minesweeper/cell/landmine.go
@@ -23,3 +23,13 @@ func (c *LandMineCell) IsFlagged() bool {
 func (c *LandMineCell) HasAdjacentLandMines() bool {
 	return false
 }
+
+func (c *LandMineCell) GetSnapshot() Snapshot {
+	if c.IsOpened() {
+		return OfLandMine()
+	}
+	if c.IsFlagged() {
+		return OfFlag()
+	}
+	return OfUnchecked()
+}

--- a/minesweeper-client/minesweeper/cell/number.go
+++ b/minesweeper-client/minesweeper/cell/number.go
@@ -27,3 +27,13 @@ func (c *NumberCell) IsFlagged() bool {
 func (c *NumberCell) HasAdjacentLandMines() bool {
 	return true
 }
+
+func (c *NumberCell) GetSnapshot() Snapshot {
+	if c.IsOpened() {
+		return OfNumber(c.adjacentLandMineCount)
+	}
+	if c.IsFlagged() {
+		return OfFlag()
+	}
+	return OfUnchecked()
+}

--- a/minesweeper-client/minesweeper/mode/single.go
+++ b/minesweeper-client/minesweeper/mode/single.go
@@ -3,6 +3,7 @@ package mode
 import (
 	"minesweeper-client/minesweeper/board"
 	"minesweeper-client/minesweeper/level"
+	"minesweeper-client/minesweeper/view"
 )
 
 type SingleMode struct {
@@ -13,6 +14,7 @@ func NewSingleMode(level level.GameLevel) *SingleMode {
 	return &SingleMode{board: board.NewBoard(level)}
 }
 
-func (mode *SingleMode) Start() {
-	mode.board.InitializeGame()
+func (m *SingleMode) Start() {
+	m.board.InitializeGame()
+	view.ShowBoard(m.board)
 }

--- a/minesweeper-client/minesweeper/mode/single.go
+++ b/minesweeper-client/minesweeper/mode/single.go
@@ -16,5 +16,7 @@ func NewSingleMode(level level.GameLevel) *SingleMode {
 
 func (m *SingleMode) Start() {
 	m.board.InitializeGame()
+
 	view.ShowBoard(m.board)
+	view.ShowRemainingFlagCount(m.board)
 }

--- a/minesweeper-client/minesweeper/util/must.go
+++ b/minesweeper-client/minesweeper/util/must.go
@@ -1,13 +1,13 @@
 package util
 
 import (
-	"minesweeper-client/minesweeper/view"
+	"fmt"
 	"os"
 )
 
 func Must[T any](value T, err error) T {
 	if err != nil {
-		view.ShowErrorMessage(err)
+		fmt.Printf("[ERROR] %s\n", err)
 		os.Exit(1)
 	}
 	return value

--- a/minesweeper-client/minesweeper/view/output.go
+++ b/minesweeper-client/minesweeper/view/output.go
@@ -11,6 +11,3 @@ func AskGameLevel() {
 func ShowSelectedGameLevel(level string) {
 	fmt.Printf("선택된 난이도: %s\n", level)
 }
-func ShowErrorMessage(err error) {
-	fmt.Printf("[ERROR] %s\n", err)
-}

--- a/minesweeper-client/minesweeper/view/output.go
+++ b/minesweeper-client/minesweeper/view/output.go
@@ -28,11 +28,17 @@ func ShowBoard(board *board.Board) {
 		for col := 0; col < board.GetColSize(); col++ {
 			cellPosition := util.Must(position.NewCellPosition(row, col))
 			cellSnapshot := board.GetSnapshot(cellPosition)
+
 			fmt.Printf("%2s ", signOf(cellSnapshot))
 		}
 		fmt.Println()
 	}
 	fmt.Println()
+}
+
+func ShowRemainingFlagCount(board *board.Board) {
+	remainingFlagCount := board.GetRemainingFlags()
+	fmt.Printf("남은 깃발 개수: %d\n\n", remainingFlagCount)
 }
 
 func showColumnNumbers(board *board.Board) {

--- a/minesweeper-client/minesweeper/view/output.go
+++ b/minesweeper-client/minesweeper/view/output.go
@@ -1,13 +1,69 @@
 package view
 
-import "fmt"
+import (
+	"fmt"
+	"minesweeper-client/minesweeper/board"
+	"minesweeper-client/minesweeper/cell"
+	"minesweeper-client/minesweeper/position"
+	"minesweeper-client/minesweeper/util"
+)
 
 func ShowGameStartMessage() {
 	fmt.Println("🎮지뢰찾기 게임을 시작합니다!")
 }
+
 func AskGameLevel() {
-	fmt.Println("난이도를 선택하세요 (easy / normal / hard)")
+	fmt.Println("\n난이도를 선택하세요 (easy / normal / hard)")
 }
+
 func ShowSelectedGameLevel(level string) {
-	fmt.Printf("선택된 난이도: %s\n", level)
+	fmt.Printf("\n선택된 난이도: %s\n\n", level)
+}
+
+func ShowBoard(board *board.Board) {
+	showColumnNumbers(board)
+
+	for row := 0; row < board.GetRowSize(); row++ {
+		fmt.Printf("%2d  ", row+1)
+		for col := 0; col < board.GetColSize(); col++ {
+			cellPosition := util.Must(position.NewCellPosition(row, col))
+			cellSnapshot := board.GetSnapshot(cellPosition)
+			fmt.Printf("%2s ", signOf(cellSnapshot))
+		}
+		fmt.Println()
+	}
+	fmt.Println()
+}
+
+func showColumnNumbers(board *board.Board) {
+	colNumbers := generateColumnNumbers(board.GetColSize())
+
+	fmt.Print("    ")
+	for _, n := range colNumbers {
+		fmt.Printf("%2d ", n)
+	}
+	fmt.Println()
+}
+
+func generateColumnNumbers(colSize int) []int {
+	numbers := make([]int, 0, colSize)
+	for i := 1; i <= colSize; i++ {
+		numbers = append(numbers, i)
+	}
+	return numbers
+}
+
+func signOf(snapshot cell.Snapshot) string {
+	switch snapshot.GetStatus() {
+	case cell.Empty:
+		return "■"
+	case cell.Flag:
+		return "⚑"
+	case cell.LandMine:
+		return "☼"
+	case cell.Number:
+		return fmt.Sprintf("%d", snapshot.GetAdjacentLandMineCount())
+	default:
+		return "□"
+	}
 }


### PR DESCRIPTION
## ✓ 연관된 이슈
[//]: # (#이슈번호)
> #8 

## ✎ 작업 내용
[//]: # (이번 PR에서 작업한 내용을 간략히 설명해주세요)
> 콘솔에 게임판을 출력하는 기능을 구현했습니다
- 콘솔에 현재 보드 상태와 남은 깃발의 개수를 출력하는 기능을 구현했습니다.
- 셀의 상태(`CellState`)를 기반으로 뷰에서 출력하기 위한 스냅샷(`CellSnapshot`) 객체를 생성하도록 구현했습니다.
- 에러 처리하는 유틸에서 에러 메시지를 출력하기 위해 뷰를 의존하고 있었는데 순환참조 문제로 직접 출력하는 방식으로 변경했습니다.
  - 추후 에러 처리하는 부분은 보완이 필요할 거 같습니다.