### PR TITLE
셀을 여는 기능 구현

### DIFF
--- a/minesweeper-client/minesweeper/board/board.go
+++ b/minesweeper-client/minesweeper/board/board.go
@@ -156,6 +156,29 @@ func (board *Board) countAdjacentLandMines(cellPosition *position.CellPosition) 
 	return adjacentLandMineCount
 }
 
+func (board *Board) openSurroundedCells(cellPosition *position.CellPosition) {
+	if board.isOpenedCell(cellPosition) {
+		return
+	}
+	if board.isFlaggedCell(cellPosition) {
+		return
+	}
+	if board.isLandMineCell(cellPosition) {
+		return
+	}
+
+	board.openCell(cellPosition)
+
+	if board.hasAdjacentLandMines(cellPosition) {
+		return
+	}
+
+	surroundedPositions := board.findSurroundedPositions(cellPosition)
+	for _, surroundedPosition := range surroundedPositions {
+		board.openSurroundedCells(surroundedPosition)
+	}
+}
+
 func (board *Board) findSurroundedPositions(cellPosition *position.CellPosition) []*position.CellPosition {
 	surroundedPositions := make([]*position.CellPosition, 0, 8)
 

--- a/minesweeper-client/minesweeper/board/board.go
+++ b/minesweeper-client/minesweeper/board/board.go
@@ -78,18 +78,13 @@ func (board *Board) Open(cellPosition *position.CellPosition) error {
 		return nil
 	}
 
-	board.openCell(cellPosition)
+	board.openSurroundedCells(cellPosition)
+
+	if board.isGameWon() {
+		board.gameStatus = Win
+	}
+
 	return nil
-}
-
-func (board *Board) openCell(cellPosition *position.CellPosition) {
-	boardCell := board.cells[cellPosition.RowIndex()][cellPosition.ColIndex()]
-	boardCell.Open()
-}
-
-func (board *Board) toggleFlagCell(cellPosition *position.CellPosition) {
-	boardCell := board.cells[cellPosition.RowIndex()][cellPosition.ColIndex()]
-	boardCell.ToggleFlag()
 }
 
 func (board *Board) IsInProgress() bool {
@@ -197,6 +192,37 @@ func (board *Board) findSurroundedPositions(cellPosition *position.CellPosition)
 
 func (board *Board) updateCell(cellPosition *position.CellPosition, cell cell.Cell) {
 	board.cells[cellPosition.RowIndex()][cellPosition.ColIndex()] = cell
+}
+
+func (board *Board) openCell(cellPosition *position.CellPosition) {
+	boardCell := board.cells[cellPosition.RowIndex()][cellPosition.ColIndex()]
+	boardCell.Open()
+}
+
+func (board *Board) toggleFlagCell(cellPosition *position.CellPosition) {
+	boardCell := board.cells[cellPosition.RowIndex()][cellPosition.ColIndex()]
+	boardCell.ToggleFlag()
+}
+
+func (board *Board) isGameWon() bool {
+	openedCellCount := board.countOpenedCells()
+
+	fullSize := board.GetRowSize() * board.GetColSize()
+	noLandMineCount := fullSize - board.landMineCount
+
+	return openedCellCount == noLandMineCount
+}
+
+func (board *Board) countOpenedCells() int {
+	var openedCellCount int
+	for _, rowCells := range board.cells {
+		for _, rowCell := range rowCells {
+			if rowCell.IsOpened() {
+				openedCellCount++
+			}
+		}
+	}
+	return openedCellCount
 }
 
 func (board *Board) isOpenedCell(cellPosition *position.CellPosition) bool {

--- a/minesweeper-client/minesweeper/board/board.go
+++ b/minesweeper-client/minesweeper/board/board.go
@@ -157,13 +157,13 @@ func (board *Board) countAdjacentLandMines(cellPosition *position.CellPosition) 
 }
 
 func (board *Board) findSurroundedPositions(cellPosition *position.CellPosition) []*position.CellPosition {
-	var surroundedPositions []*position.CellPosition
+	surroundedPositions := make([]*position.CellPosition, 0, 8)
 
-	for _, surroundedPosition := range position.SurroundedPositions {
-		if cellPosition.CannotMoveBy(surroundedPosition) {
+	for _, relativePosition := range position.RelativePositions {
+		if cellPosition.CannotMoveBy(relativePosition) {
 			continue
 		}
-		movedPosition := util.FatalIfError(cellPosition.MovedBy(surroundedPosition))
+		movedPosition := util.FatalIfError(cellPosition.MovedBy(relativePosition))
 		if board.IsOutOfBounds(movedPosition) {
 			continue
 		}

--- a/minesweeper-client/minesweeper/minesweeper.go
+++ b/minesweeper-client/minesweeper/minesweeper.go
@@ -12,13 +12,22 @@ type Minesweeper struct {
 func (minesweeper *Minesweeper) Run() {
 	view.ShowGameStartMessage()
 
-	gameLevel, err := readInputGameLevel()
-	if err != nil {
-		view.ShowErrorMessage(err)
-	}
+	gameLevel := readGameLevelWithRetry()
 
 	gameMode := mode.NewSingleMode(gameLevel)
 	gameMode.Start()
+}
+
+func readGameLevelWithRetry() level.GameLevel {
+	for {
+		selectedLevel, err := readInputGameLevel()
+		if err != nil {
+			view.ShowErrorMessage(err)
+			continue
+		}
+
+		return selectedLevel
+	}
 }
 
 func readInputGameLevel() (level.GameLevel, error) {

--- a/minesweeper-client/minesweeper/position/relative_position.go
+++ b/minesweeper-client/minesweeper/position/relative_position.go
@@ -5,7 +5,7 @@ type RelativePosition struct {
 	DeltaCol int
 }
 
-var SurroundedPositions = []RelativePosition{
+var RelativePositions = []RelativePosition{
 	{-1, -1},
 	{-1, 0},
 	{-1, 1},


### PR DESCRIPTION
## ✓ 연관된 이슈
[//]: # (#이슈번호)
> #12 

## ✎ 작업 내용
[//]: # (이번 PR에서 작업한 내용을 간략히 설명해주세요)
> 재귀적으로 셀을 여는 기능을 구현했습니다
- 지정 좌표의 칸을 오픈하고, 주변 지뢰 수가 0이면 인접 칸을 재귀적으로 오픈합니다.
  - 오픈 조건: 닫혀있는 경우, 깃발이 아닌 경우, 지뢰가 아닌 경우
- 열린 칸 수가 `전체 칸 수 - 지뢰 수`와 같으면 승리로 판정합니다.
- 난이도 입력이 잘못된 경우 재입력 받는 방식으로 수정했습니다.